### PR TITLE
Fixed an issue with hooks not removing on run end

### DIFF
--- a/Diluvian/HarbDifficultyDef.cs
+++ b/Diluvian/HarbDifficultyDef.cs
@@ -25,6 +25,7 @@ namespace Diluvian
 
         public float EliteModifier { get; protected set; }
 
+        public bool HooksApplied { get; protected set; }
         public abstract void ApplyHooks();
         public abstract void UndoHooks();
 

--- a/Diluvian/Syzygy.cs
+++ b/Diluvian/Syzygy.cs
@@ -105,11 +105,12 @@ namespace Diluvian
                     Diluvian.DiluvianPlugin.GetLogger().LogInfo("Attempted to start game without having unlocked the achievement for it!");
                     RoR2.CharacterBody.onBodyStartGlobal += CharacterBody_onBodyStartGlobal;
                 }
+                HooksApplied = true;
             }
         }
         public override void UndoHooks()
         {
-            if (NetworkServer.active)
+            if (HooksApplied)
             {
                 RoR2.SceneDirector.onGenerateInteractableCardSelection -= RemoveCleansingPools;
                 IL.RoR2.GenericPickupController.OnTriggerStay -= LunarsUnConsentional;
@@ -120,6 +121,7 @@ namespace Diluvian
                     illegalAccess = false;
                     CharacterBody.onBodyStartGlobal -= CharacterBody_onBodyStartGlobal;
                 }
+                HooksApplied = false;
             }
         }
 


### PR DESCRIPTION
The issue was that if you leave from the game to the main menu `NetworkServer.active` is false when `onRunDestroyGlobal` is executed. So, I've changed a check to remove hooks if they are applied.

Though, unsubscribing from hooks even if you not subscribed will not throw an error and work just fine. But that's up to you if you want remove that check completely.